### PR TITLE
Support HR Fix in A1111 [A1111 Dev]

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,5 +93,4 @@ If the default remove bg cannot achieve your desired effect, you can use other t
 
 ## Known Issue
 
-- For **Automatic1111** implementation, **Hires. Fix** is not supported yet. This is caused by A1111 code structure, which is hard to modify. We might want to make our own fork of A1111 later to make it work, as PR is not likely to get merged in A1111 repo.
 - `Restore Details` does not work properly when the input and output aspect ratios are different

--- a/libiclight/a1111_backend.py
+++ b/libiclight/a1111_backend.py
@@ -64,12 +64,13 @@ def apply_ic_light(
         return new_forward
 
     # Patch unet forward.
-    p.model_patcher.add_module_patch(
+    model_patcher = p.get_model_patcher()
+    model_patcher.add_module_patch(
         "diffusion_model", ModulePatch(create_new_forward_func=apply_c_concat)
     )
 
     # Patch weights.
-    p.model_patcher.add_patches(
+    model_patcher.add_patches(
         patches={
             "diffusion_model." + key: (value.to(dtype=dtype, device=device),)
             for key, value in ic_model_state_dict.items()

--- a/scripts/ic_light_script.py
+++ b/scripts/ic_light_script.py
@@ -155,12 +155,10 @@ class ICLightScript(scripts.Script):
                 interactive=True,
             )
 
-            with InputAccordion(
-                value=False, label="Restore Details"
-            ) as detail_transfer:
+            with InputAccordion(value=False, label="Restore Details") as detail_transfer:
 
                 detail_transfer_use_raw_input = gr.Checkbox(
-                    label="Use the [Image with Background Removed] instead of the [Original Input]"
+                    label="Use the [Original Input] instead of the [Image with Background Removed]"
                 )
 
                 detail_transfer_blur_radius = gr.Slider(

--- a/scripts/ic_light_script.py
+++ b/scripts/ic_light_script.py
@@ -155,10 +155,12 @@ class ICLightScript(scripts.Script):
                 interactive=True,
             )
 
-            with InputAccordion(value=False, label="Restore Details") as detail_transfer:
+            with InputAccordion(
+                value=False, label="Restore Details"
+            ) as detail_transfer:
 
                 detail_transfer_use_raw_input = gr.Checkbox(
-                    label="Use the [Original Input] instead of the [Image with Background Removed]"
+                    label="Use the [Image with Background Removed] instead of the [Original Input]"
                 )
 
                 detail_transfer_blur_radius = gr.Slider(
@@ -264,28 +266,13 @@ class ICLightScript(scripts.Script):
 
         self.args = args
 
-    def process(self, p: StableDiffusionProcessing, *args, **kwargs):
-        """A1111 impl."""
-        if self.backend_type != BackendType.A1111:
-            return
-
-        if (self.args is None) or (not self.args.enabled):
-            return
-
-        if isinstance(p, StableDiffusionProcessingTxt2Img) and getattr(
-            p, "enable_hr", False
-        ):
-            raise NotImplementedError("Hires-fix is not yet supported in A1111.")
-
-        self.apply_ic_light(p, self.args)
-
     def process_before_every_sampling(
         self, p: StableDiffusionProcessing, *args, **kwargs
     ):
-        """Forge impl."""
-        if self.backend_type == BackendType.A1111:
-            return
-
+        """
+        Similar to process(), called before every sampling.
+        If you use high-res fix, this will be called twice.
+        """
         if (self.args is None) or (not self.args.enabled):
             return
 


### PR DESCRIPTION
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15984 adds `process_before_every_sampling` scirpt hook to A1111. The PR enables us unifying the handling of A1111 and SD Forge.

This PR makes IC-Light + HR Fix available in A1111.

To use this PR, you need
- Checkout A1111 dev
- Update sd-webui-model-patcher to https://github.com/huchenlei/sd-webui-model-patcher/commit/307d12d970147442d3f4e9abcecfd1c4404ecf4b [2024-06-10]
- Checkout this PR

I will merge this PR once https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15984 made into master.
